### PR TITLE
sumire: use specific idProduct for usb paths

### DIFF
--- a/aosp_e6653.mk
+++ b/aosp_e6653.mk
@@ -47,4 +47,4 @@ PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sf.lcd_density=480 \
-    ro.usb.pid_suffix=1C9
+    ro.usb.pid_suffix=1D9


### PR DESCRIPTION
from: 32.0.A.4.11

Signed-off-by: David Viteri davidteri91@gmail.com
