### PR TITLE
sumire: remove double zygote prop

### DIFF
--- a/aosp_e6653.mk
+++ b/aosp_e6653.mk
@@ -17,9 +17,6 @@ TARGET_KERNEL_CONFIG := aosp_kitakami_sumire_defconfig
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/sumire/overlay
 
-# Use zygote64_32
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.zygote=zygote64_32
-
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)


### PR DESCRIPTION
inherit: https://android.googlesource.com/platform/build/+/android-6.0.0_r1/target/product/core_64_bit.mk#30
defines in default.prop

Signed-off-by: David Viteri davidteri91@gmail.com
