### PR TITLE
sumire: Enable simple PowerHAL for native double-tap-to-wake

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -15,3 +15,6 @@
 include device/sony/kitakami/BoardConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := E6653
+
+TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
+TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
Signed-off-by: Adam Farden adam@farden.cz
Signed-off-by: David Viteri davidteri91@gmail.com
