### PR TITLE
sumire: drop TARGET_TAP_TO_WAKE_STRING

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -17,4 +17,3 @@ include device/sony/kitakami/BoardConfig.mk
 TARGET_BOOTLOADER_BOARD_NAME := E6653
 
 TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
-TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
it was used on shinano due to sirius path isn't using 1 : 0 for tap to wake feature... here this is not needed

Signed-off-by: David Viteri davidteri91@gmail.com
