### PR TITLE
sumire: Add property for the 8/23MP Switch in ES

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -61,6 +61,10 @@ PRODUCT_PACKAGES += \
     InCallUI \
     Stk
 
+## 8MP Switch for ES
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.camera.8mp.config=true
+
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi


### PR DESCRIPTION
Enable 8MP by default
