### PR TITLE
thermanager: update maximum GPU frequency

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -128,7 +128,7 @@
 	</control>
 
 	<control name="gpu">
-		<mitigation level="off"><value resource="kgsl-3d0">600000000</value></mitigation>
+		<mitigation level="off"><value resource="kgsl-3d0">630000000</value></mitigation>
 		<mitigation level="1"><value resource="kgsl-3d0">510000000</value></mitigation>
 		<mitigation level="2"><value resource="kgsl-3d0">450000000</value></mitigation>
 		<mitigation level="3"><value resource="kgsl-3d0">390000000</value></mitigation>


### PR DESCRIPTION
Sumire uses msm8994 v2.1 so the maximum GPU frequency should be 630MHz instead of 600MHz.