### PR TITLE
sumire: add NFA_PROPRIETARY_CFG for proper Mifare Classic support

### DIFF
--- a/rootdir/system/etc/libnfc-brcm.conf
+++ b/rootdir/system/etc/libnfc-brcm.conf
@@ -353,3 +353,17 @@ AID_MATCHING_MODE=0x01
 # eSE               0x01
 # UICC              0x02
 NXP_PRFD_TECH_SE=0x02
+
+###############################################################################
+# Vendor Specific Proprietary Protocol & Discovery Configuration
+# Set to 0xFF if unsupported
+#  byte[0] NCI_PROTOCOL_18092_ACTIVE
+#  byte[1] NCI_PROTOCOL_B_PRIME
+#  byte[2] NCI_PROTOCOL_DUAL
+#  byte[3] NCI_PROTOCOL_15693
+#  byte[4] NCI_PROTOCOL_KOVIO
+#  byte[5] NCI_PROTOCOL_MIFARE
+#  byte[6] NCI_DISCOVERY_TYPE_POLL_KOVIO
+#  byte[7] NCI_DISCOVERY_TYPE_POLL_B_PRIME
+#  byte[8] NCI_DISCOVERY_TYPE_LISTEN_B_PRIME
+NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:77:FF:FF}


### PR DESCRIPTION
* NFC stack in Android M has native support for Mifare Classic,
  but default protocol number is wrong. This property will correct
  the number for PN547C2.
* Mostly copied from sample configuration, with
  NCI_DISCOVERY_TYPE_POLL_KOVIO changed to 0x77. Any other value will
  cause errorneous commands sent to NFCC, and NFC stack will fall into
  infinite loop.
* PSE and Android Beam is working.