### PR TITLE
Update Call Speaker mixer path for fluence enabled

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -2601,7 +2601,7 @@
     </path>
 
     <path name="voice-speaker-dmic-ef">
-        <path name="speaker-dmic-endfire" />
+        <path name="voice-speaker-mic" />
     </path>
 
     <path name="voice-rec-dmic-ef">


### PR DESCRIPTION
Use the mixer path maintained by Xperia for Call Speaker and Playback Speaker